### PR TITLE
SRFE-8790 Address Iframe memory leaks

### DIFF
--- a/packages/rrdom/src/index.ts
+++ b/packages/rrdom/src/index.ts
@@ -368,7 +368,7 @@ export class Mirror implements IMirror<RRNode> {
 
   // removes the node from idNodeMap
   // doesn't remove the node from nodeMetaMap
-  removeNodeFromMap(n: RRNode) {
+  removeNodeFromMap(n: RRNode, _permanent?: boolean) {
     const id = this.getId(n);
     this.idNodeMap.delete(id);
 

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -214,6 +214,18 @@ export class Mirror implements IMirror<Node> {
       );
     }
   }
+
+  removeNodeFromMapPermanently(n: Node) {
+    const id = this.getId(n);
+    this.idNodeMap.delete(id);
+    this.nodeMetaMap.delete(n);
+
+    if (n.childNodes) {
+      n.childNodes.forEach((childNode) =>
+        this.removeNodeFromMapPermanently(childNode as unknown as Node),
+      );
+    }
+  }
   has(id: number): boolean {
     return this.idNodeMap.has(id);
   }

--- a/packages/rrweb-snapshot/src/utils.ts
+++ b/packages/rrweb-snapshot/src/utils.ts
@@ -203,26 +203,15 @@ export class Mirror implements IMirror<Node> {
   }
 
   // removes the node from idNodeMap
-  // doesn't remove the node from nodeMetaMap
-  removeNodeFromMap(n: Node) {
+  // if permanent is true, also removes from nodeMetaMap
+  removeNodeFromMap(n: Node, permanent = false) {
     const id = this.getId(n);
     this.idNodeMap.delete(id);
+    if (permanent) this.nodeMetaMap.delete(n);
 
     if (n.childNodes) {
       n.childNodes.forEach((childNode) =>
-        this.removeNodeFromMap(childNode as unknown as Node),
-      );
-    }
-  }
-
-  removeNodeFromMapPermanently(n: Node) {
-    const id = this.getId(n);
-    this.idNodeMap.delete(id);
-    this.nodeMetaMap.delete(n);
-
-    if (n.childNodes) {
-      n.childNodes.forEach((childNode) =>
-        this.removeNodeFromMapPermanently(childNode as unknown as Node),
+        this.removeNodeFromMap(childNode as unknown as Node, permanent),
       );
     }
   }

--- a/packages/rrweb-snapshot/test/utils.test.ts
+++ b/packages/rrweb-snapshot/test/utils.test.ts
@@ -283,7 +283,7 @@ describe('utils', () => {
   });
 
   describe('Mirror', () => {
-    describe('removeNodeFromMapPermanently', () => {
+    describe('removeNodeFromMap with permanent flag', () => {
       it('should remove node from both idNodeMap and nodeMetaMap', () => {
         const mirror = new Mirror();
         const div = document.createElement('div');
@@ -300,7 +300,7 @@ describe('utils', () => {
         expect(mirror.hasNode(div)).toBe(true);
         expect(mirror.getNode(1)).toBe(div);
 
-        mirror.removeNodeFromMapPermanently(div);
+        mirror.removeNodeFromMap(div, true);
 
         expect(mirror.getId(div)).toBe(-1);
         expect(mirror.hasNode(div)).toBe(false);
@@ -358,7 +358,7 @@ describe('utils', () => {
         expect(mirror.hasNode(child2)).toBe(true);
         expect(mirror.hasNode(grandchild)).toBe(true);
 
-        mirror.removeNodeFromMapPermanently(parent);
+        mirror.removeNodeFromMap(parent, true);
 
         expect(mirror.hasNode(parent)).toBe(false);
         expect(mirror.hasNode(child1)).toBe(false);
@@ -370,7 +370,7 @@ describe('utils', () => {
         expect(mirror.getId(grandchild)).toBe(-1);
       });
 
-      it('should differ from removeNodeFromMap by also clearing nodeMetaMap', () => {
+      it('should differ from non-permanent removeNodeFromMap by also clearing nodeMetaMap', () => {
         const mirror1 = new Mirror();
         const div1 = document.createElement('div');
         const meta1 = {
@@ -399,9 +399,9 @@ describe('utils', () => {
         } as serializedNodeWithId;
 
         mirror2.add(div2, meta2);
-        mirror2.removeNodeFromMapPermanently(div2);
+        mirror2.removeNodeFromMap(div2, true);
 
-        // removeNodeFromMapPermanently clears both maps
+        // removeNodeFromMap with permanent=true clears both maps
         expect(mirror2.getNode(1)).toBeNull();
         expect(mirror2.hasNode(div2)).toBe(false); // Also removed from nodeMetaMap
       });

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -80,11 +80,8 @@ export class IframeManager {
   public removeIframe(iframeEl: HTMLIFrameElement): void {
     const storedDoc = this.iframeContentDocumentMap.get(iframeEl);
 
-    this.stylesheetManager.cleanupStylesheetsForRemovedNode(
-      iframeEl,
-      storedDoc,
-    );
     if (storedDoc) {
+      this.stylesheetManager.cleanupStylesheetsForRemovedNode(storedDoc);
       this.mirror.removeNodeFromMap(storedDoc, true);
     }
 

--- a/packages/rrweb/src/record/iframe-manager.ts
+++ b/packages/rrweb/src/record/iframe-manager.ts
@@ -78,6 +78,16 @@ export class IframeManager {
   }
 
   public removeIframe(iframeEl: HTMLIFrameElement): void {
+    const storedDoc = this.iframeContentDocumentMap.get(iframeEl);
+
+    this.stylesheetManager.cleanupStylesheetsForRemovedNode(
+      iframeEl,
+      storedDoc,
+    );
+    if (storedDoc) {
+      this.mirror.removeNodeFromMap(storedDoc, true);
+    }
+
     this.iframes.delete(iframeEl);
     this.iframeContentDocumentMap.delete(iframeEl);
 

--- a/packages/rrweb/src/record/index.ts
+++ b/packages/rrweb/src/record/index.ts
@@ -4,7 +4,11 @@ import {
   type SlimDOMOptions,
   createMirror,
 } from 'rrweb-snapshot';
-import { initObservers, mutationBuffers, removeMutationBufferForDoc } from './observer';
+import {
+  initObservers,
+  mutationBuffers,
+  removeMutationBufferForDoc,
+} from './observer';
 import {
   on,
   getWindowWidth,

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -372,8 +372,12 @@ export default class MutationBuffer {
       if (removedNode.nodeName === 'IFRAME') {
         const iframeEl = removedNode as HTMLIFrameElement;
         try {
-          const storedDoc = this.iframeManager.getIframeContentDocument(iframeEl);
-          this.stylesheetManager.cleanupStylesheetsForRemovedNode(removedNode, storedDoc);
+          const storedDoc =
+            this.iframeManager.getIframeContentDocument(iframeEl);
+          this.stylesheetManager.cleanupStylesheetsForRemovedNode(
+            removedNode,
+            storedDoc,
+          );
           if (storedDoc) {
             this.mirror.removeNodeFromMapPermanently(storedDoc);
           }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -370,18 +370,8 @@ export default class MutationBuffer {
       const removedNode = this.mapRemoves.shift()!;
 
       if (removedNode.nodeName === 'IFRAME') {
-        const iframeEl = removedNode as HTMLIFrameElement;
         try {
-          const storedDoc =
-            this.iframeManager.getIframeContentDocument(iframeEl);
-          this.stylesheetManager.cleanupStylesheetsForRemovedNode(
-            removedNode,
-            storedDoc,
-          );
-          if (storedDoc) {
-            this.mirror.removeNodeFromMapPermanently(storedDoc);
-          }
-          this.iframeManager.removeIframe(iframeEl);
+          this.iframeManager.removeIframe(removedNode as HTMLIFrameElement);
         } catch (e) {
           // Ignore errors during iframe cleanup
         }

--- a/packages/rrweb/src/record/observer.ts
+++ b/packages/rrweb/src/record/observer.ts
@@ -102,6 +102,15 @@ export function initMutationObserver(
   return observer;
 }
 
+export function removeMutationBufferForDoc(doc: Document): void {
+  for (let i = mutationBuffers.length - 1; i >= 0; i--) {
+    const buffer = mutationBuffers[i];
+    if (buffer.getDoc() === doc) {
+      mutationBuffers.splice(i, 1);
+    }
+  }
+}
+
 function initMoveObserver({
   mousemoveCb,
   sampling,

--- a/packages/rrweb/src/record/stylesheet-manager.ts
+++ b/packages/rrweb/src/record/stylesheet-manager.ts
@@ -106,7 +106,9 @@ export class StylesheetManager {
             }
           }
 
-          const styleElements = doc.querySelectorAll('style, link[rel="stylesheet"]');
+          const styleElements = doc.querySelectorAll(
+            'style, link[rel="stylesheet"]',
+          );
           styleElements.forEach((el) => {
             const sheet = (el as HTMLStyleElement | HTMLLinkElement).sheet;
             if (sheet) {

--- a/packages/rrweb/src/record/stylesheet-manager.ts
+++ b/packages/rrweb/src/record/stylesheet-manager.ts
@@ -84,6 +84,65 @@ export class StylesheetManager {
     this.trackedLinkElements = new WeakSet();
   }
 
+  /**
+   * Cleans up stylesheets associated with a removed node.
+   *
+   * @param removedNode - The node that was removed from the DOM.
+   * @param storedDocument - Optional stored document reference for iframes,
+   *                         since contentDocument becomes null after removal.
+   */
+  public cleanupStylesheetsForRemovedNode(
+    removedNode: Node,
+    storedDocument?: Document,
+  ): void {
+    if (removedNode.nodeName === 'IFRAME') {
+      const iframe = removedNode as HTMLIFrameElement;
+      try {
+        const doc = storedDocument || iframe.contentDocument;
+        if (doc) {
+          if (doc.adoptedStyleSheets) {
+            for (const sheet of doc.adoptedStyleSheets) {
+              this.styleMirror.remove(sheet);
+            }
+          }
+
+          const styleElements = doc.querySelectorAll('style, link[rel="stylesheet"]');
+          styleElements.forEach((el) => {
+            const sheet = (el as HTMLStyleElement | HTMLLinkElement).sheet;
+            if (sheet) {
+              this.styleMirror.remove(sheet);
+            }
+          });
+        }
+      } catch (e) {
+        // Ignore errors
+      }
+    }
+
+    if (removedNode.nodeName === 'STYLE') {
+      const styleEl = removedNode as HTMLStyleElement;
+      if (styleEl.sheet) {
+        this.styleMirror.remove(styleEl.sheet);
+      }
+    }
+
+    if (
+      removedNode.nodeName === 'LINK' &&
+      (removedNode as HTMLLinkElement).rel === 'stylesheet'
+    ) {
+      const linkEl = removedNode as HTMLLinkElement;
+      if (linkEl.sheet) {
+        this.styleMirror.remove(linkEl.sheet);
+      }
+    }
+
+    if (removedNode.childNodes) {
+      removedNode.childNodes.forEach((child) => {
+        this.cleanupStylesheetsForRemovedNode(child);
+      });
+    }
+  }
+
   // TODO: take snapshot on stylesheet reload by applying event listener
   private trackStylesheetInLinkElement(_linkEl: HTMLLinkElement) {
     // linkEl.addEventListener('load', () => {

--- a/packages/rrweb/src/record/stylesheet-manager.ts
+++ b/packages/rrweb/src/record/stylesheet-manager.ts
@@ -88,60 +88,42 @@ export class StylesheetManager {
    * Cleans up stylesheets associated with a removed node.
    *
    * @param removedNode - The node that was removed from the DOM.
-   * @param storedDocument - Optional stored document reference for iframes,
-   *                         since contentDocument becomes null after removal.
    */
-  public cleanupStylesheetsForRemovedNode(
-    removedNode: Node,
-    storedDocument?: Document,
-  ): void {
-    if (removedNode.nodeName === 'IFRAME') {
-      const iframe = removedNode as HTMLIFrameElement;
-      try {
-        const doc = storedDocument || iframe.contentDocument;
-        if (doc) {
-          if (doc.adoptedStyleSheets) {
-            for (const sheet of doc.adoptedStyleSheets) {
-              this.styleMirror.remove(sheet);
-            }
+  public cleanupStylesheetsForRemovedNode(removedNode: Node): void {
+    try {
+      if (removedNode.nodeType === Node.DOCUMENT_NODE) {
+        const doc = removedNode as Document;
+        if (doc.adoptedStyleSheets) {
+          for (const sheet of doc.adoptedStyleSheets) {
+            this.styleMirror.remove(sheet);
           }
-
-          const styleElements = doc.querySelectorAll(
-            'style, link[rel="stylesheet"]',
-          );
-          styleElements.forEach((el) => {
-            const sheet = (el as HTMLStyleElement | HTMLLinkElement).sheet;
-            if (sheet) {
-              this.styleMirror.remove(sheet);
-            }
-          });
         }
-      } catch (e) {
-        // Ignore errors
       }
-    }
 
-    if (removedNode.nodeName === 'STYLE') {
-      const styleEl = removedNode as HTMLStyleElement;
-      if (styleEl.sheet) {
-        this.styleMirror.remove(styleEl.sheet);
+      if (removedNode.nodeName === 'STYLE') {
+        const styleEl = removedNode as HTMLStyleElement;
+        if (styleEl.sheet) {
+          this.styleMirror.remove(styleEl.sheet);
+        }
       }
-    }
 
-    if (
-      removedNode.nodeName === 'LINK' &&
-      (removedNode as HTMLLinkElement).rel === 'stylesheet'
-    ) {
-      const linkEl = removedNode as HTMLLinkElement;
-      if (linkEl.sheet) {
-        this.styleMirror.remove(linkEl.sheet);
+      if (
+        removedNode.nodeName === 'LINK' &&
+        (removedNode as HTMLLinkElement).rel === 'stylesheet'
+      ) {
+        const linkEl = removedNode as HTMLLinkElement;
+        if (linkEl.sheet) {
+          this.styleMirror.remove(linkEl.sheet);
+        }
       }
-    }
 
-    if (removedNode.childNodes) {
-      removedNode.childNodes.forEach((child) => {
-        this.cleanupStylesheetsForRemovedNode(child);
-      });
+      if (removedNode.childNodes) {
+        removedNode.childNodes.forEach((child) => {
+          this.cleanupStylesheetsForRemovedNode(child);
+        });
+      }
+    } catch (e) {
+      // Ignore errors
     }
   }
 

--- a/packages/rrweb/src/utils.ts
+++ b/packages/rrweb/src/utils.ts
@@ -501,6 +501,16 @@ export class StyleSheetMirror {
   generateId(): number {
     return this.id++;
   }
+
+  remove(stylesheet: CSSStyleSheet): boolean {
+    const id = this.styleIDMap.get(stylesheet);
+    if (id !== undefined) {
+      this.styleIDMap.delete(stylesheet);
+      this.idStyleMap.delete(id);
+      return true;
+    }
+    return false;
+  }
 }
 
 /**

--- a/packages/rrweb/test/util.test.ts
+++ b/packages/rrweb/test/util.test.ts
@@ -80,6 +80,36 @@ describe('Utilities for other modules', () => {
       for (let i = 0; i < 10; i++) expect(mirror.getStyle(i + 1)).toBeNull();
       expect(mirror.add(new CSSStyleSheet())).toBe(1);
     });
+
+    it('can remove CSSStyleSheet from the mirror', () => {
+      const mirror = new StyleSheetMirror();
+      const styleSheet = new CSSStyleSheet();
+      mirror.add(styleSheet);
+      expect(mirror.has(styleSheet)).toBeTruthy();
+      expect(mirror.remove(styleSheet)).toBe(true);
+      expect(mirror.has(styleSheet)).toBeFalsy();
+      expect(mirror.getId(styleSheet)).toBe(-1);
+    });
+
+    it('returns false when removing a non-existent stylesheet', () => {
+      const mirror = new StyleSheetMirror();
+      const styleSheet = new CSSStyleSheet();
+      expect(mirror.remove(styleSheet)).toBe(false);
+    });
+
+    it('does not affect other stylesheets when removing one', () => {
+      const mirror = new StyleSheetMirror();
+      const styleSheet1 = new CSSStyleSheet();
+      const styleSheet2 = new CSSStyleSheet();
+      mirror.add(styleSheet1);
+      mirror.add(styleSheet2);
+      const id2 = mirror.getId(styleSheet2);
+      mirror.remove(styleSheet1);
+      expect(mirror.has(styleSheet1)).toBeFalsy();
+      expect(mirror.has(styleSheet2)).toBeTruthy();
+      expect(mirror.getId(styleSheet2)).toBe(id2);
+      expect(mirror.getStyle(id2)).toBe(styleSheet2);
+    });
   });
 
   describe('inDom()', () => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -830,6 +830,8 @@ export interface IMirror<TNode> {
 
   removeNodeFromMap(n: TNode): void;
 
+  removeNodeFromMapPermanently?(n: TNode): void;
+
   has(id: number): boolean;
 
   hasNode(node: TNode): boolean;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -828,9 +828,7 @@ export interface IMirror<TNode> {
 
   getMeta(n: TNode): serializedNodeWithId | null;
 
-  removeNodeFromMap(n: TNode): void;
-
-  removeNodeFromMapPermanently?(n: TNode): void;
+  removeNodeFromMap(n: TNode, permanent?: boolean): void;
 
   has(id: number): boolean;
 


### PR DESCRIPTION
Upstream PR: https://github.com/rrweb-io/rrweb/pull/1791

Fix memory leaks when iframes are removed from DOM (SRFE-8790) 
- Add proper cleanup for iframe content documents, mutation observers, and stylesheets when iframes are removed from the DOM
- Add removeNodeFromMapPermanently to Mirror class for permanent node removal (vs temporary removal for moved nodes)                                                        
                                                                                                                                                                              
Problem: When an iframe is removed from the DOM, several resources were not being cleaned up:
1. Mirror maps: idNodeMap had strong references to iframe's contentDocument and all its child nodes, preventing GC
2. MutationBuffer: The buffer for the iframe's document remained in the mutationBuffers array
3. StyleSheetMirror: Stylesheets from the iframe remained tracked, holding references to the removed document
4. Observer handlers: The iframe's mutation observer handler remained in the handlers array

Validated against a local site that creates/destroys iframes. Noticed a ton of references being held on to stylesheets, mutation observers in as shown in the screenshots below

<img width="1897" height="939" alt="Screenshot 2026-02-03 at 10 08 07 AM" src="https://github.com/user-attachments/assets/b7701e32-f859-45c8-bc4f-2b6fb7d925ff" />

<img width="1473" height="824" alt="Screenshot 2026-02-03 at 9 51 07 AM" src="https://github.com/user-attachments/assets/f548a4e8-a9fa-4695-a9f3-e6acaf74e414" />

After fix the memory is stable
<img width="1915" height="1011" alt="Screenshot 2026-02-04 at 11 50 40 AM" src="https://github.com/user-attachments/assets/b45071b8-1210-4224-a4a6-416135089f91" />

