### PR TITLE
SRFE-8790 cleanup child nodes recursively

### DIFF
--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -368,17 +368,7 @@ export default class MutationBuffer {
 
     while (this.mapRemoves.length) {
       const removedNode = this.mapRemoves.shift()!;
-
-      if (removedNode.nodeName === 'IFRAME') {
-        try {
-          this.iframeManager.removeIframe(removedNode as HTMLIFrameElement);
-        } catch (e) {
-          // Ignore errors during iframe cleanup
-        }
-      } else {
-        this.stylesheetManager.cleanupStylesheetsForRemovedNode(removedNode);
-      }
-
+      this.cleanupRemovedNode(removedNode);
       this.mirror.removeNodeFromMap(removedNode);
     }
 
@@ -816,6 +806,26 @@ export default class MutationBuffer {
         });
       }
     }
+  };
+
+  private cleanupRemovedNode = (node: Node) => {
+    if (node.nodeName === 'IFRAME') {
+      try {
+        this.iframeManager.removeIframe(node as HTMLIFrameElement);
+      } catch (e) {
+        // Ignore errors during iframe cleanup
+      }
+    } else {
+      try {
+        this.stylesheetManager.cleanupStylesheetsForRemovedNode(node);
+      } catch (e) {
+        // Ignore errors during stylesheet cleanup
+      }
+    }
+
+    node.childNodes.forEach((child) => {
+      this.cleanupRemovedNode(child);
+    });
   };
 }
 


### PR DESCRIPTION
Worked on this some more. The previous [change](https://github.com/mixpanel/rrweb/pull/8) helped was using `removeNodeFromMap` which recursively went through the child nodes to remove them from the map which holds strong references thus preventing GC. But for iframes, we also need to check contentDocument 

In this change we recurse through the child nodes as well as part of cleanup.. Attaching a log file as well which shows a decrease in the mirror size.

[logs4.txt](https://github.com/user-attachments/files/25885027/logs4.txt)

Also updated upstream pr https://github.com/rrweb-io/rrweb/pull/1791/changes
